### PR TITLE
Implement --label filter on `yogit pr list` command

### DIFF
--- a/yogit/api/statements.py
+++ b/yogit/api/statements.py
@@ -130,6 +130,13 @@ PULL_REQUEST_LIST_STATEMENT = """
                     url
                     title
                     mergeable
+                    labels(first: 100) {
+                        edges {
+                            node {
+                                name
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -154,6 +161,13 @@ ORGA_PULL_REQUEST_LIST_STATEMENT = """
                     number
                     url
                     title
+                    labels(first: 100) {
+                        edges {
+                            node {
+                                name
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/yogit/yogit/pullrequest.py
+++ b/yogit/yogit/pullrequest.py
@@ -17,17 +17,24 @@ def pull_request():
 
 @click.command("list", help="List your opened pull requests")
 @click.option("--orga", type=click.STRING, help="Expand results to a specific organization")
+@click.option(
+    "--label",
+    type=click.STRING,
+    multiple=True,
+    help="Only show pull requests having such label (several --label can be set)",
+)
 @click.pass_context
 @account_required
 @check_update
-def pull_request_list(ctx, orga):  # pylint: disable=unused-argument
+def pull_request_list(ctx, orga, label):  # pylint: disable=unused-argument
     """
     List pull requests
     """
+    labels = [x.lower() for x in label]
     if orga:
-        query = OrgaPullRequestListQuery(orga)
+        query = OrgaPullRequestListQuery(labels, orga)
     else:
-        query = PullRequestListQuery()
+        query = PullRequestListQuery(labels)
     query.execute()  # pylint: disable=no-value-for-parameter
     query.print()
 


### PR DESCRIPTION
Development sponsored by https://github.com/Genymobile as part of the #hacktoberfest.

Add `--label` option to `yogit pr list` command in order to filter by label.

* You can set multiple `--label` options to filter on several labels
* Label is case insensitive

Use case:

`yogit pr list --orga genymobile --label "awaiting qa"`
`yogit pr list --label "work in progress" --label "do not merge"`

